### PR TITLE
Добавлена возможность передвать дополнительные параметры в params 

### DIFF
--- a/src/entities/Note.php
+++ b/src/entities/Note.php
@@ -119,7 +119,8 @@ class Note extends BaseEntity
      */
     protected $fieldList = [
         'id', 'element_id', 'element_type', 'note_type',
-        'text', 'created_at', 'updated_at', 'responsible_user_id'
+        'text', 'created_at', 'updated_at', 'responsible_user_id',
+        'params'
     ];
 
     /**

--- a/src/traits/FieldList.php
+++ b/src/traits/FieldList.php
@@ -19,7 +19,13 @@ trait FieldList
             $fields[$field] = isset($this->$field) ? $this->$field : null;
         }
 
-        $fields = array_filter($fields, 'strlen');
+        $fields = array_filter($fields, function ($field) {
+            if (is_array($field)) {
+                return !empty($field);
+            }
+
+            return strlen($field);
+        });
 
         return $fields;
     }


### PR DESCRIPTION
Типы событий, для которых обязателен массив params


10-11 | 'params' => ['UNIQ' =>'676sdfs7fsdf','LINK' => 'www.testweb.ru/test_call.mp3','PHONE' => '84950000001','DURATION' => 58,'SRC' => 'asterisk'] | Параметры для создания события типа "звонок". Массив params передаётся вместо параметра text.
-- | -- | --
25 | 'params' => ['text' => 'Текст системного сообщения'] | Для типа события "системное сообщение", текст передаётся с помощью массива params, вместо параметра text.
102-103 | 'params' => ['text' => 'Текст cмс сообщения'] | Для типа события "cмс сообщение", текст передаётся с помощью массива params, вместо параметра text.



