### PR TITLE
Добавлена возможность указывать кто изменил сделку.

### DIFF
--- a/src/entities/Lead.php
+++ b/src/entities/Lead.php
@@ -37,12 +37,18 @@ class Lead extends CustomizableEntity
     public $tags;
 
     /**
+     * @var int Id пользователя изменившего сущность, если 0, то робот
+     */
+    public $modified_user_id;
+
+    /**
      * @var array
      */
     protected $fieldList = [
         'id', 'name', 'created_at', 'updated_at',
         'status_id', 'pipeline_id', 'responsible_user_id',
-        'sale', 'tags', 'contacts_id', 'company_id'
+        'sale', 'tags', 'contacts_id', 'company_id',
+        'modified_user_id'
     ];
 
     use CompanyLinkable,


### PR DESCRIPTION
В документации этого нет, но в техподдержке сказали: 

> При отправке modified_user_id = 0 сделка будет обновлена от Робота (без участия конкретного пользователя), а при смене этапа сделки событие так же будет создано от Робота. Данная информация будет добавлена в нашу документацию. 